### PR TITLE
[Issue 8] Add "list" command, which shows configured groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,9 @@ List hosts associated to specific group:
 $ vagrant group hosts <group-name>
 ```
 
+List groups:
+```
+$ vagrant group list [<group-name>]
+```
+> If group name is omitted, show all groups
+

--- a/lib/vagrant-group/command.rb
+++ b/lib/vagrant-group/command.rb
@@ -2,7 +2,7 @@ module VagrantPlugins
   module Group
     class Command < Vagrant.plugin(2, :command)
 
-      COMMANDS = %w(up halt destroy provision reload hosts suspend resume)
+      COMMANDS = %w(up halt destroy provision reload hosts suspend resume list)
 
       def self.synopsis
         'runs vagrant command on specific group of VMs'

--- a/lib/vagrant-group/command.rb
+++ b/lib/vagrant-group/command.rb
@@ -47,7 +47,9 @@ module VagrantPlugins
           return nil
         end
 
-        if action == 'hosts'
+        if action == 'list'
+          puts groups
+        elsif action == 'hosts'
           groups.each do |group|
             print_hosts(group)
           end

--- a/lib/vagrant-group/command.rb
+++ b/lib/vagrant-group/command.rb
@@ -36,7 +36,7 @@ module VagrantPlugins
         action = argv[0]
         patterns = argv[1]
 
-        if !patterns || !action || !COMMANDS.include?(action)
+        if (!patterns && action != 'list') || !action || !COMMANDS.include?(action)
           safe_puts(opts.help)
           return nil
         end

--- a/lib/vagrant-group/command.rb
+++ b/lib/vagrant-group/command.rb
@@ -41,10 +41,14 @@ module VagrantPlugins
           return nil
         end
 
-        groups = find_groups(patterns.split(","))
-        if groups.length == 0
-          @env.ui.error('No groups matched the pattern given.')
-          return nil
+        unless action == 'list' && !patterns
+          groups = find_groups(patterns.split(","))
+          if groups.length == 0
+            @env.ui.error('No groups matched the pattern given.')
+            return nil
+          end
+        else
+          groups = all_groups.split(",")
         end
 
         if action == 'list'


### PR DESCRIPTION
This change include the `list` command, which shows groups matching user-supplied pattern or, if no pattern is given, shows all groups configured in Vagrant